### PR TITLE
Fix wasm build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,6 @@ exclude = ["assets/**/*"]
 
 [dependencies]
 anyhow = "1"
-bevy = "0.4"
+bevy = { version = "0.4", default-features = false }
 ron = "0.6.4"
 serde = "1"


### PR DESCRIPTION
This seems pretty handy.

Bevy's features and their interactions with third party crates are still a bit mysterious to me but I think that this thing doesn't need any of the default features.

Making this change seems to allow the thing to work with my wasm-targeting project.